### PR TITLE
Publish Voucher Response support for newer API version

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ Grab via Maven:
 <dependency>
   <groupId>io.voucherify.client</groupId>
   <artifactId>voucherify-java-sdk</artifactId>
-  <version>5.3.0</version>
+  <version>6.0.0</version>
 </dependency>
 ```
 
 or via Gradle
 ```groovy
-compile 'io.voucherify.client:voucherify-java-sdk:5.3.0'
+compile 'io.voucherify.client:voucherify-java-sdk:6.0.0'
 
 ```
 
@@ -525,6 +525,28 @@ Check [customer object](https://docs.voucherify.io/v1/reference#the-customer-obj
 voucherify.events.track(CustomEvent customEvent)
 ```
 
+---
+
+### Migration to 6.0
+
+Version 6.0 of the SDK is not backwards compatible with previous version
+Changes made in version 6.0 relate to `PublishVoucherResponse` class and `RollbackRedemptionResponse` class.
+
+#### Classes changes
+
+* `RollbackRedemptionResponse` class uses `VoucherResponse` class as type for `voucher` field instead of `PublishVoucherResponse`
+* `PublishVoucherResponse` class has additional fields to be compatible with API version - `2017-04-20`:
+
+  * `id`
+  * `object`
+  * `createdAt`
+  * `customerId`
+  * `trackingId`
+  * `voucher`
+
+  When API version `2017-04-05` is used, the `PublishVoucherResponse` object returned from `distributions().publish` call will use older structure and new fields will be set to null.
+  Developers using API version `2017-04-05` can still safely use access returned fields as before.  
+  When API version `2017-04-20` is used, the `PublisherVoucherResponse` object returned from `distributions().publish` call will use new structure and new fields will be set to proper values.
 ---
 
 ### Migration to 5.0

--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ Changes made in version 6.0 relate to `PublishVoucherResponse` class and `Rollba
   * `voucher`
 
   When API version `2017-04-05` is used, the `PublishVoucherResponse` object returned from `distributions().publish` call will use older structure and new fields will be set to null.
-  Developers using API version `2017-04-05` can still safely use access returned fields as before.  
+  Developers using API version `2017-04-05` can still safely access returned fields as before.  
   When API version `2017-04-20` is used, the `PublisherVoucherResponse` object returned from `distributions().publish` call will use new structure and new fields will be set to proper values.
 ---
 

--- a/README.md
+++ b/README.md
@@ -629,6 +629,7 @@ voucherify.vouchers().async().create(createVoucher, new VoucherifyCallback<Vouch
 Bug reports and pull requests are welcome on GitHub at https://github.com/rspective/voucherify-java-sdk.
 
 ## Changelog
+* 2018-04-04 - 6.0.0 - Response from Publish Voucher method now includes additional fields and structure introduced when using `ApiVersion.V_2017_04_20`. RollbackRedemptionResponse object uses VoucherResponse as voucher field instead of PublishVoucherResponse.
 * 2018-04-03 - 5.3.2 - Add missing fields in Validation and Redeem responses, provide more examples related to percent discount voucher.
 * 2018-04-03 - 5.3.1 - Add Order to Validation response.
 * 2018-01-14 - 5.3.0 - API Version set in header by default, Events API, Orders API, added missing methods to Customers, Distributions and Campaigns modules.

--- a/README.md
+++ b/README.md
@@ -629,7 +629,7 @@ voucherify.vouchers().async().create(createVoucher, new VoucherifyCallback<Vouch
 Bug reports and pull requests are welcome on GitHub at https://github.com/rspective/voucherify-java-sdk.
 
 ## Changelog
-* 2018-04-04 - 6.0.0 - Response from Publish Voucher method now includes additional fields and structure introduced when using `ApiVersion.V_2017_04_20`. RollbackRedemptionResponse object uses VoucherResponse as voucher field instead of PublishVoucherResponse.
+* 2018-04-04 - 6.0.0 - Response from Publish Voucher method now includes additional fields and structure introduced when using `ApiVersion.V_2017_04_20`. `RollbackRedemptionResponse` object uses VoucherResponse as voucher field instead of `PublishVoucherResponse`.
 * 2018-04-03 - 5.3.2 - Add missing fields in Validation and Redeem responses, provide more examples related to percent discount voucher.
 * 2018-04-03 - 5.3.1 - Add Order to Validation response.
 * 2018-01-14 - 5.3.0 - API Version set in header by default, Events API, Orders API, added missing methods to Customers, Distributions and Campaigns modules.

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ sourceCompatibility = 1.6
 targetCompatibility = 1.6
 
 group = 'io.voucherify.client'
-version = '5.3.2'
+version = '6.0.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/voucherify/client/model/distribution/response/PublishVoucherResponse.java
+++ b/src/main/java/io/voucherify/client/model/distribution/response/PublishVoucherResponse.java
@@ -6,6 +6,7 @@ import io.voucherify.client.model.voucher.Gift;
 import io.voucherify.client.model.voucher.VoucherType;
 import io.voucherify.client.model.voucher.response.VoucherPublishResponse;
 import io.voucherify.client.model.voucher.response.VoucherRedemptionResponse;
+import io.voucherify.client.model.voucher.response.VoucherResponse;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -66,4 +67,18 @@ public class PublishVoucherResponse {
   @JsonProperty("updated_at")
   private Date updatedAt;
 
+  private String id;
+
+  private String object;
+
+  @JsonProperty("created_at")
+  private Date createdAt;
+
+  @JsonProperty("customer_id")
+  private String customerId;
+
+  @JsonProperty("tracking_id")
+  private String trackingId;
+
+  private VoucherResponse voucher;
 }

--- a/src/main/java/io/voucherify/client/model/redemption/response/RollbackRedemptionResponse.java
+++ b/src/main/java/io/voucherify/client/model/redemption/response/RollbackRedemptionResponse.java
@@ -1,12 +1,12 @@
 package io.voucherify.client.model.redemption.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.voucherify.client.model.voucher.response.VoucherResponse;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import io.voucherify.client.model.distribution.response.PublishVoucherResponse;
 import io.voucherify.client.model.redemption.RollbackStatus;
 
 import java.util.Date;
@@ -33,5 +33,5 @@ public class RollbackRedemptionResponse {
 
   private RollbackStatus status;
 
-  private PublishVoucherResponse voucher;
+  private VoucherResponse voucher;
 }

--- a/src/test/java/io/voucherify/client/module/DistributionsModuleTest.java
+++ b/src/test/java/io/voucherify/client/module/DistributionsModuleTest.java
@@ -48,6 +48,26 @@ public class DistributionsModuleTest extends AbstractModuleTest {
   }
 
   @Test
+  public void shouldPublishVoucherWithParentPublicationStructure() {
+    // given
+    enqueueResponse("{\"id\" : \"pub_testId\", \"voucher\" : {  \"code\" : \"some-code\", \"campaign\": \"some-campaign\" } }");
+
+    // when
+    PublishVoucherResponse result = client.distributions().publish(PUBLISH_VOUCHER);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getCode()).isNull();
+    assertThat(result.getId()).isEqualTo("pub_testId");
+    assertThat(result.getVoucher()).isNotNull();
+    assertThat(result.getVoucher().getCode()).isEqualTo("some-code");
+    assertThat(result.getVoucher().getCampaign()).isEqualTo("some-campaign");
+    RecordedRequest request = getRequest();
+    assertThat(request.getPath()).isEqualTo("/vouchers/publish");
+    assertThat(request.getMethod()).isEqualTo("POST");
+  }
+
+  @Test
   public void shouldCreateExport() {
     // given
     CreateExport createExport = CreateExport.builder().exportedObject("voucher").build();
@@ -132,6 +152,22 @@ public class DistributionsModuleTest extends AbstractModuleTest {
   public void shouldPublishVoucherAsync() {
     // given
     enqueueResponse("{\"code\" : \"some-code\", \"campaign\": \"some-campaign\" }");
+    VoucherifyCallback callback = createCallback();
+
+    // when
+    client.distributions().async().publish(PUBLISH_VOUCHER, callback);
+
+    // then
+    await().atMost(5, SECONDS).until(wasCallbackFired());
+    RecordedRequest request = getRequest();
+    assertThat(request.getPath()).isEqualTo("/vouchers/publish");
+    assertThat(request.getMethod()).isEqualTo("POST");
+  }
+
+  @Test
+  public void shouldPublishVoucherWithParentPublicationStructureAsync() {
+    // given
+    enqueueResponse("{\"id\" : \"pub_testId\", \"voucher\" : {  \"code\" : \"some-code\", \"campaign\": \"some-campaign\" } }");
     VoucherifyCallback callback = createCallback();
 
     // when
@@ -238,6 +274,27 @@ public class DistributionsModuleTest extends AbstractModuleTest {
     // then
     PublishVoucherResponse result = observable.toBlocking().first();
     assertThat(result).isNotNull();
+    RecordedRequest request = getRequest();
+    assertThat(request.getPath()).isEqualTo("/vouchers/publish");
+    assertThat(request.getMethod()).isEqualTo("POST");
+  }
+
+  @Test
+  public void shouldPublishVoucherWithParentPublicationStructureRxJava() {
+    // given
+    enqueueResponse("{\"id\" : \"pub_testId\", \"voucher\" : {  \"code\" : \"some-code\", \"campaign\": \"some-campaign\" } }");
+
+    // when
+    Observable<PublishVoucherResponse> observable = client.distributions().rx().publish(PUBLISH_VOUCHER);
+
+    // then
+    PublishVoucherResponse result = observable.toBlocking().first();
+    assertThat(result).isNotNull();
+    assertThat(result.getCode()).isNull();
+    assertThat(result.getId()).isEqualTo("pub_testId");
+    assertThat(result.getVoucher()).isNotNull();
+    assertThat(result.getVoucher().getCode()).isEqualTo("some-code");
+    assertThat(result.getVoucher().getCampaign()).isEqualTo("some-campaign");
     RecordedRequest request = getRequest();
     assertThat(request.getPath()).isEqualTo("/vouchers/publish");
     assertThat(request.getMethod()).isEqualTo("POST");


### PR DESCRIPTION
### Changes:  
1. `RollbackRedemptionResponse` now ueses `VoucherResponse` for `voucher` fiield  
2.  Added missing fields: `id`, `object`, `created_at`,  `customer_id`, `tracking_id` for  `PublishVoucherResponse`. Addiotionaly `PublishVoucherResponse` now contains `voucher` field.  
By doing so backward compatibility for API - `2017-04-05` will work. And for API - `2017-04-20`, `voucher` field will be mapped with correct properties.