### PR TITLE
11.2.1 - adding missing fields to `DiscountResponse`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ Grab via Maven:
 <dependency>
   <groupId>io.voucherify.client</groupId>
   <artifactId>voucherify-java-sdk</artifactId>
-  <version>11.3.0</version>
+  <version>11.2.1</version>
 </dependency>
 ```
 
 or via Gradle
 ```groovy
-compile 'io.voucherify.client:voucherify-java-sdk:11.3.0'
+compile 'io.voucherify.client:voucherify-java-sdk:11.2.1'
 
 ```
 
@@ -918,7 +918,7 @@ voucherify.vouchers().async().create(createVoucher, new VoucherifyCallback<Vouch
 Bug reports and pull requests are welcome on GitHub at https://github.com/rspective/voucherify-java-sdk.
 
 ## Changelog
-* 2024-03-12 - 11.3.0 - Added all supported fields to `DiscountResponse`. Changed `effect` from `String` to `DiscountEffect` type. Thanks to [mariaivanova-git](https://github.com/mariaivanova-git) for issue request
+* 2024-03-12 - 11.2.1 - Added all supported fields to `DiscountResponse`. Thanks to [mariaivanova-git](https://github.com/mariaivanova-git) for issue request
 * 2023-10-26 - 11.2.0 -
   * Added `APPLY_TO_ITEMS_BY_QUANTITY` discount type. Added [Update Products in bulk] method. Thanks to [@viglu](https://github.com/viglu) for contribution!
   * Added missing properties to OrderResponse and OrderItemResponse models. Thanks to [@petro-dutchak-infopulse](https://github.com/petro-dutchak-infopulse) for issue request!

--- a/README.md
+++ b/README.md
@@ -918,7 +918,7 @@ voucherify.vouchers().async().create(createVoucher, new VoucherifyCallback<Vouch
 Bug reports and pull requests are welcome on GitHub at https://github.com/rspective/voucherify-java-sdk.
 
 ## Changelog
-* 2024-03-12 - 11.3.0 - Added all supported fields to `DiscountResponse`. Changed `effect` from `String` to `DiscountEffect` type.
+* 2024-03-12 - 11.3.0 - Added all supported fields to `DiscountResponse`. Changed `effect` from `String` to `DiscountEffect` type. Thanks to [mariaivanova-git](https://github.com/mariaivanova-git) for issue request
 * 2023-10-26 - 11.2.0 -
   * Added `APPLY_TO_ITEMS_BY_QUANTITY` discount type. Added [Update Products in bulk] method. Thanks to [@viglu](https://github.com/viglu) for contribution!
   * Added missing properties to OrderResponse and OrderItemResponse models. Thanks to [@petro-dutchak-infopulse](https://github.com/petro-dutchak-infopulse) for issue request!

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ Grab via Maven:
 <dependency>
   <groupId>io.voucherify.client</groupId>
   <artifactId>voucherify-java-sdk</artifactId>
-  <version>11.2.0</version>
+  <version>11.3.0</version>
 </dependency>
 ```
 
 or via Gradle
 ```groovy
-compile 'io.voucherify.client:voucherify-java-sdk:11.2.0'
+compile 'io.voucherify.client:voucherify-java-sdk:11.3.0'
 
 ```
 
@@ -918,6 +918,7 @@ voucherify.vouchers().async().create(createVoucher, new VoucherifyCallback<Vouch
 Bug reports and pull requests are welcome on GitHub at https://github.com/rspective/voucherify-java-sdk.
 
 ## Changelog
+* 2024-03-12 - 11.3.0 - Added all supported fields to `DiscountResponse`. Changed `effect` from `String` to `DiscountEffect` type.
 * 2023-10-26 - 11.2.0 -
   * Added `APPLY_TO_ITEMS_BY_QUANTITY` discount type. Added [Update Products in bulk] method. Thanks to [@viglu](https://github.com/viglu) for contribution!
   * Added missing properties to OrderResponse and OrderItemResponse models. Thanks to [@petro-dutchak-infopulse](https://github.com/petro-dutchak-infopulse) for issue request!

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group = 'io.voucherify.client'
-version = '11.2.0'
+version = '11.3.0'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group = 'io.voucherify.client'
-version = '11.3.0'
+version = '11.2.1'
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/voucherify/client/model/stackable/response/DiscountResponse.java
+++ b/src/main/java/io/voucherify/client/model/stackable/response/DiscountResponse.java
@@ -19,7 +19,7 @@ public class DiscountResponse {
   private String type;
 
   @JsonProperty("effect")
-  private DiscountEffect effect;
+  private String effect;
 
   @JsonProperty("amount_off")
   private Long amountOff;

--- a/src/main/java/io/voucherify/client/model/stackable/response/DiscountResponse.java
+++ b/src/main/java/io/voucherify/client/model/stackable/response/DiscountResponse.java
@@ -3,7 +3,6 @@ package io.voucherify.client.model.stackable.response;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.voucherify.client.model.product.Product;
 import io.voucherify.client.model.product.SKU;
-import io.voucherify.client.model.voucher.DiscountEffect;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/io/voucherify/client/model/stackable/response/DiscountResponse.java
+++ b/src/main/java/io/voucherify/client/model/stackable/response/DiscountResponse.java
@@ -18,7 +18,6 @@ public class DiscountResponse {
 
   private String type;
 
-  @JsonProperty("effect")
   private String effect;
 
   @JsonProperty("amount_off")

--- a/src/main/java/io/voucherify/client/model/stackable/response/DiscountResponse.java
+++ b/src/main/java/io/voucherify/client/model/stackable/response/DiscountResponse.java
@@ -1,6 +1,9 @@
 package io.voucherify.client.model.stackable.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.voucherify.client.model.product.Product;
+import io.voucherify.client.model.product.SKU;
+import io.voucherify.client.model.voucher.DiscountEffect;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,10 +17,46 @@ import lombok.ToString;
 public class DiscountResponse {
 
   private String type;
-  private String effect;
+
+  @JsonProperty("effect")
+  private DiscountEffect effect;
 
   @JsonProperty("amount_off")
   private Long amountOff;
+
+  @JsonProperty("percent_off")
+  private Double percentOff;
+
+  @JsonProperty("fixed_amount")
+  private Double fixedAmount;
+
+  @JsonProperty("fixed_amount_formula")
+  private String fixedAmountFormula;
+
+  @JsonProperty("percent_off_formula")
+  private String percentOffFormula;
+
+  @JsonProperty("amount_limit")
+  private Double amountLimit;
+
+  @JsonProperty("amount_off_formula")
+  private String amountOffFormula;
+
+  @JsonProperty("aggregated_amount_limit")
+  private Long aggregatedAmountLimit;
+
+  @JsonProperty("unit_off")
+  private Long unitOff;
+
+  @JsonProperty("unit_off_formula")
+  private String unitOffFormula;
+
+  @JsonProperty("unit_type")
+  private String unitType;
+
+  private Product product;
+
+  private SKU sku;
 
   @JsonProperty("is_dynamic")
   private Boolean isDynamic;

--- a/src/main/java/io/voucherify/client/model/stackable/response/DiscountResponse.java
+++ b/src/main/java/io/voucherify/client/model/stackable/response/DiscountResponse.java
@@ -30,29 +30,29 @@ public class DiscountResponse {
   @JsonProperty("fixed_amount")
   private Double fixedAmount;
 
-  @JsonProperty("fixed_amount_formula")
-  private String fixedAmountFormula;
+  @JsonProperty("unit_off")
+  private Long unitOff;
 
-  @JsonProperty("percent_off_formula")
-  private String percentOffFormula;
+  @JsonProperty("unit_type")
+  private String unitType;
 
   @JsonProperty("amount_limit")
   private Double amountLimit;
 
-  @JsonProperty("amount_off_formula")
-  private String amountOffFormula;
-
   @JsonProperty("aggregated_amount_limit")
   private Long aggregatedAmountLimit;
 
-  @JsonProperty("unit_off")
-  private Long unitOff;
+  @JsonProperty("amount_off_formula")
+  private String amountOffFormula;
+
+  @JsonProperty("percent_off_formula")
+  private String percentOffFormula;
+
+  @JsonProperty("fixed_amount_formula")
+  private String fixedAmountFormula;
 
   @JsonProperty("unit_off_formula")
   private String unitOffFormula;
-
-  @JsonProperty("unit_type")
-  private String unitType;
 
   private Product product;
 


### PR DESCRIPTION
I used current docs as a support https://docs.voucherify.io/reference/validate-stacked-discounts.
I validated all type of coupons with test app to ensure everything is working.