### PR TITLE
11.2.2 - Fixed missing `getValue` in `Expand` enums.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ Grab via Maven:
 <dependency>
   <groupId>io.voucherify.client</groupId>
   <artifactId>voucherify-java-sdk</artifactId>
-  <version>11.2.1</version>
+  <version>11.2.2</version>
 </dependency>
 ```
 
 or via Gradle
 ```groovy
-compile 'io.voucherify.client:voucherify-java-sdk:11.2.1'
+compile 'io.voucherify.client:voucherify-java-sdk:11.2.2'
 
 ```
 
@@ -918,6 +918,7 @@ voucherify.vouchers().async().create(createVoucher, new VoucherifyCallback<Vouch
 Bug reports and pull requests are welcome on GitHub at https://github.com/rspective/voucherify-java-sdk.
 
 ## Changelog
+* 2024-07-04 - 11.2.2 - Fixed missing `getValue` in `Expand` enums.
 * 2024-03-12 - 11.2.1 - Added all supported fields to `DiscountResponse`. Thanks to [mariaivanova-git](https://github.com/mariaivanova-git) for issue request
 * 2023-10-26 - 11.2.0 -
   * Added `APPLY_TO_ITEMS_BY_QUANTITY` discount type. Added [Update Products in bulk] method. Thanks to [@viglu](https://github.com/viglu) for contribution!

--- a/README.md
+++ b/README.md
@@ -918,7 +918,7 @@ voucherify.vouchers().async().create(createVoucher, new VoucherifyCallback<Vouch
 Bug reports and pull requests are welcome on GitHub at https://github.com/rspective/voucherify-java-sdk.
 
 ## Changelog
-* 2024-07-04 - 11.2.2 - Fixed missing `getValue` in `Expand` enums.
+* 2024-07-04 - 11.2.2 - Fixed missing `getValue` in `Expand` enums. Added missing `VALIDATION_RULES` property to stacked endpoints option.
 * 2024-03-12 - 11.2.1 - Added all supported fields to `DiscountResponse`. Thanks to [mariaivanova-git](https://github.com/mariaivanova-git) for issue request
 * 2023-10-26 - 11.2.0 -
   * Added `APPLY_TO_ITEMS_BY_QUANTITY` discount type. Added [Update Products in bulk] method. Thanks to [@viglu](https://github.com/viglu) for contribution!

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group = 'io.voucherify.client'
-version = '11.2.1'
+version = '11.2.2'
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/voucherify/client/model/qualifications/Expand.java
+++ b/src/main/java/io/voucherify/client/model/qualifications/Expand.java
@@ -1,5 +1,7 @@
 package io.voucherify.client.model.qualifications;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum Expand {
 
   REDEEMABLE("redeemable"),
@@ -9,5 +11,10 @@ public enum Expand {
 
   Expand(String value) {
     this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
   }
 }

--- a/src/main/java/io/voucherify/client/model/stackable/Expand.java
+++ b/src/main/java/io/voucherify/client/model/stackable/Expand.java
@@ -1,5 +1,7 @@
 package io.voucherify.client.model.stackable;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum Expand {
 
   ORDER("order"),
@@ -11,5 +13,10 @@ public enum Expand {
 
   Expand(String value) {
     this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
   }
 }

--- a/src/main/java/io/voucherify/client/model/stackable/Expand.java
+++ b/src/main/java/io/voucherify/client/model/stackable/Expand.java
@@ -7,7 +7,8 @@ public enum Expand {
   ORDER("order"),
   REDEMPTION("redemption"),
   REDEEMABLE("redeemable"),
-  CATEGORY("category");
+  CATEGORY("category"),
+  VALIDATION_RULES("validation_rules");
 
   private final String value;
 


### PR DESCRIPTION
# Why
Missing those properties caused errors:

```
{
    "code": 400,
    "key": "invalid_payload",
    "message": "Invalid payload",
    "details": "Property .options.expand.0 must be equal to one of the allowed values [ redeemable, category, validation_rules ]",
    "request_id": "v-0f0138a0bb60e609fd"
}
```

```
{
    "code": 400,
    "key": "invalid_payload",
    "message": "Invalid payload",
    "details": "Property .options.expand.0 must be equal to one of the allowed values [ order, redemption, redeemable, category, validation_rules ]",
    "request_id": "v-0f0138d29460e609ff"
}
```

Also there was missing `VALIDATION_RULES` property in the stacked endpoints option.