### PR TITLE
12.0.0 - Fix mapping for `result` and `status` properties in redemption objects. Add `applicable_to` property to `BusinessValidationRule` object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ Grab via Maven:
 <dependency>
   <groupId>io.voucherify.client</groupId>
   <artifactId>voucherify-java-sdk</artifactId>
-  <version>11.2.1</version>
+  <version>12.0.0</version>
 </dependency>
 ```
 
 or via Gradle
 ```groovy
-compile 'io.voucherify.client:voucherify-java-sdk:11.2.1'
+compile 'io.voucherify.client:voucherify-java-sdk:12.0.0'
 
 ```
 
@@ -918,6 +918,7 @@ voucherify.vouchers().async().create(createVoucher, new VoucherifyCallback<Vouch
 Bug reports and pull requests are welcome on GitHub at https://github.com/rspective/voucherify-java-sdk.
 
 ## Changelog
+* 2024-07-08 - 12.0.0 - Fix mapping for `result` and `status` properties in redemption objects. Add `applicable_to` property to `BusinessValidationRule` object.
 * 2024-03-12 - 11.2.1 - Added all supported fields to `DiscountResponse`. Thanks to [mariaivanova-git](https://github.com/mariaivanova-git) for issue request
 * 2023-10-26 - 11.2.0 -
   * Added `APPLY_TO_ITEMS_BY_QUANTITY` discount type. Added [Update Products in bulk] method. Thanks to [@viglu](https://github.com/viglu) for contribution!

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group = 'io.voucherify.client'
-version = '11.2.1'
+version = '12.0.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/voucherify/client/model/redemption/RedemptionResult.java
+++ b/src/main/java/io/voucherify/client/model/redemption/RedemptionResult.java
@@ -1,0 +1,6 @@
+package io.voucherify.client.model.redemption;
+
+public enum RedemptionResult {
+  SUCCESS,
+  FAILURE
+}

--- a/src/main/java/io/voucherify/client/model/redemption/RedemptionStatus.java
+++ b/src/main/java/io/voucherify/client/model/redemption/RedemptionStatus.java
@@ -1,6 +1,7 @@
 package io.voucherify.client.model.redemption;
 
 public enum RedemptionStatus {
-  SUCCESS,
-  FAILURE
+  SUCCEEDED,
+  FAILED,
+  ROLLED_BACK
 }

--- a/src/main/java/io/voucherify/client/model/redemption/RedemptionsFilter.java
+++ b/src/main/java/io/voucherify/client/model/redemption/RedemptionsFilter.java
@@ -22,7 +22,7 @@ public class RedemptionsFilter extends AbstractFilter<String, Object> {
 
   private Integer page;
 
-  private RedemptionStatus result;
+  private RedemptionResult result;
 
   private String customer;
 

--- a/src/main/java/io/voucherify/client/model/redemption/RollbackResult.java
+++ b/src/main/java/io/voucherify/client/model/redemption/RollbackResult.java
@@ -1,0 +1,6 @@
+package io.voucherify.client.model.redemption;
+
+public enum RollbackResult {
+  SUCCESS,
+  FAILURE
+}

--- a/src/main/java/io/voucherify/client/model/redemption/RollbackStatus.java
+++ b/src/main/java/io/voucherify/client/model/redemption/RollbackStatus.java
@@ -1,6 +1,6 @@
 package io.voucherify.client.model.redemption;
 
 public enum RollbackStatus {
-  SUCCESS,
-  FAILURE
+  SUCCEEDED,
+  FAILED
 }

--- a/src/main/java/io/voucherify/client/model/redemption/response/RedeemVoucherResponse.java
+++ b/src/main/java/io/voucherify/client/model/redemption/response/RedeemVoucherResponse.java
@@ -3,6 +3,7 @@ package io.voucherify.client.model.redemption.response;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.voucherify.client.model.loyalties.Reward;
 import io.voucherify.client.model.order.response.OrderResponse;
+import io.voucherify.client.model.redemption.RedemptionResult;
 import io.voucherify.client.model.redemption.RedemptionStatus;
 import io.voucherify.client.model.voucher.response.VoucherResponse;
 import lombok.AccessLevel;
@@ -33,7 +34,9 @@ public class RedeemVoucherResponse {
 
   private OrderResponse order;
 
-  private RedemptionStatus result;
+  private RedemptionResult result;
+
+  private RedemptionStatus status;
 
   private VoucherResponse voucher;
 

--- a/src/main/java/io/voucherify/client/model/redemption/response/RedemptionEntryResponse.java
+++ b/src/main/java/io/voucherify/client/model/redemption/response/RedemptionEntryResponse.java
@@ -2,6 +2,7 @@ package io.voucherify.client.model.redemption.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.voucherify.client.model.order.response.OrderResponse;
+import io.voucherify.client.model.redemption.RedemptionResult;
 import io.voucherify.client.model.redemption.RedemptionStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -40,7 +41,9 @@ public class RedemptionEntryResponse {
 
   private Map<String, Object> metadata;
 
-  private RedemptionStatus result;
+  private RedemptionResult result;
+
+  private RedemptionStatus status;
 
   @JsonProperty("failure_code")
   private String failureCode;

--- a/src/main/java/io/voucherify/client/model/redemption/response/RollbackRedemptionResponse.java
+++ b/src/main/java/io/voucherify/client/model/redemption/response/RollbackRedemptionResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.voucherify.client.model.customer.response.CustomerResponse;
 import io.voucherify.client.model.order.response.OrderResponse;
 import io.voucherify.client.model.promotion.response.TierResponse;
+import io.voucherify.client.model.redemption.RollbackResult;
 import io.voucherify.client.model.redemption.RollbackStatus;
 import io.voucherify.client.model.rewards.response.RewardResponse;
 import io.voucherify.client.model.voucher.response.VoucherResponse;
@@ -38,8 +39,8 @@ public class RollbackRedemptionResponse {
 
   private String redemption;
 
-  //TODO: FIX result and status in next major version
-  @JsonProperty("result")
+  private RollbackResult result;
+
   private RollbackStatus status;
 
   private OrderResponse order;

--- a/src/main/java/io/voucherify/client/model/stackable/response/RedemptionResponse.java
+++ b/src/main/java/io/voucherify/client/model/stackable/response/RedemptionResponse.java
@@ -3,6 +3,7 @@ package io.voucherify.client.model.stackable.response;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.voucherify.client.model.customer.response.CustomerResponse;
 import io.voucherify.client.model.order.response.OrderResponse;
+import io.voucherify.client.model.redemption.RedemptionResult;
 import io.voucherify.client.model.redemption.RedemptionStatus;
 import io.voucherify.client.model.voucher.response.VoucherResponse;
 
@@ -37,9 +38,9 @@ public class RedemptionResponse {
 
   private String redemption;
 
-  //TODO: FIX result and status in next major version
+  private RedemptionResult result;
 
-  private RedemptionStatus result;
+  private RedemptionStatus status;
 
   private OrderResponse order;
 

--- a/src/main/java/io/voucherify/client/model/validationRules/ApplicableTo.java
+++ b/src/main/java/io/voucherify/client/model/validationRules/ApplicableTo.java
@@ -1,0 +1,54 @@
+package io.voucherify.client.model.validationRules;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@ToString
+public class ApplicableTo {
+
+  private ApplicableToObjectType object;
+
+  private String id;
+
+  @JsonProperty("source_id")
+  private String sourceId;
+
+  @JsonProperty("product_id")
+  private String productId;
+
+  @JsonProperty("product_source_id")
+  private String productSourceId;
+
+  private Boolean strict;
+
+  private Double price;
+
+  @JsonProperty("price_formula")
+  private Double priceFormula;
+
+  private ApplicableToEffect effect;
+
+  @JsonProperty("quantity_limit")
+  private Integer quantityLimit;
+
+  @JsonProperty("aggregated_quantity_limit")
+  private Integer aggregatedQuantityLimit;
+
+  @JsonProperty("amount_limit")
+  private Integer amountLimit;
+
+  @JsonProperty("aggregated_amount_limit")
+  private Integer aggregatedAmountLimit;
+
+  @JsonProperty("order_item_indices")
+  private List<Integer> orderItemIndices;
+}

--- a/src/main/java/io/voucherify/client/model/validationRules/ApplicableToEffect.java
+++ b/src/main/java/io/voucherify/client/model/validationRules/ApplicableToEffect.java
@@ -1,0 +1,22 @@
+package io.voucherify.client.model.validationRules;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+
+@Getter
+public enum ApplicableToEffect {
+  EVERY("APPLY_TO_EVERY"),
+  CHEAPEST("APPLY_TO_CHEAPEST"),
+  MOST_EXPENSIVE("APPLY_TO_MOST_EXPENSIVE");
+
+  private final String value;
+
+  ApplicableToEffect(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+    public String getValue() {
+      return value;
+  }
+}

--- a/src/main/java/io/voucherify/client/model/validationRules/ApplicableToObjectType.java
+++ b/src/main/java/io/voucherify/client/model/validationRules/ApplicableToObjectType.java
@@ -1,0 +1,22 @@
+package io.voucherify.client.model.validationRules;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+
+@Getter
+public enum ApplicableToObjectType {
+  PRODUCT("product"),
+  SKU("sku"),
+  PRODUCTS_COLLECTION("products_collection");
+
+  private final String value;
+
+  ApplicableToObjectType(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+}

--- a/src/main/java/io/voucherify/client/model/validationRules/ApplicationRules.java
+++ b/src/main/java/io/voucherify/client/model/validationRules/ApplicationRules.java
@@ -1,0 +1,24 @@
+package io.voucherify.client.model.validationRules;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@ToString
+public class ApplicationRules {
+
+    private List<ApplicableTo> excluded;
+
+    private List<ApplicableTo> included;
+
+    @JsonProperty("included_all")
+    private Boolean includedAll;
+}

--- a/src/main/java/io/voucherify/client/model/validationRules/response/BusinessValidationRule.java
+++ b/src/main/java/io/voucherify/client/model/validationRules/response/BusinessValidationRule.java
@@ -1,6 +1,8 @@
 package io.voucherify.client.model.validationRules.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.voucherify.client.model.Json;
+import io.voucherify.client.model.validationRules.ApplicationRules;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -24,4 +26,7 @@ public class BusinessValidationRule {
   private String object;
 
   private Date createdAt;
+
+  @JsonProperty("applicable_to")
+  private ApplicationRules applicableTo;
 }

--- a/src/test/java/io/voucherify/client/module/RedemptionsModuleTest.java
+++ b/src/test/java/io/voucherify/client/module/RedemptionsModuleTest.java
@@ -7,7 +7,7 @@ import io.voucherify.client.model.order.Order;
 import io.voucherify.client.model.order.OrderItem;
 import io.voucherify.client.model.redemption.RedeemPromotion;
 import io.voucherify.client.model.redemption.RedeemVoucher;
-import io.voucherify.client.model.redemption.RedemptionStatus;
+import io.voucherify.client.model.redemption.RedemptionResult;
 import io.voucherify.client.model.redemption.RedemptionsFilter;
 import io.voucherify.client.model.redemption.RollbackRedemption;
 import io.voucherify.client.model.redemption.response.RedeemPromotionResponse;
@@ -112,7 +112,7 @@ public class RedemptionsModuleTest extends AbstractModuleTest {
             .campaign("campaign")
             .limit(10)
             .page(5)
-            .result(RedemptionStatus.SUCCESS)
+            .result(RedemptionResult.SUCCESS)
             .build();
 
     enqueueResponse("{}");
@@ -261,7 +261,7 @@ public class RedemptionsModuleTest extends AbstractModuleTest {
             .campaign("campaign")
             .limit(10)
             .page(5)
-            .result(RedemptionStatus.SUCCESS)
+            .result(RedemptionResult.SUCCESS)
             .build();
 
     enqueueResponse("{}");
@@ -414,7 +414,7 @@ public class RedemptionsModuleTest extends AbstractModuleTest {
             .campaign("campaign")
             .limit(10)
             .page(5)
-            .result(RedemptionStatus.SUCCESS)
+            .result(RedemptionResult.SUCCESS)
             .build();
 
     enqueueResponse("{}");


### PR DESCRIPTION
## WHY
- The `result` and `status` properties were not correctly mapped after adding the `status` property to the API. As the types have completely changed, we must release a new major version, as this is a breaking change.
- Add `applicable_to` property to `BusinessValidationRule` object, as it was missing