### PR TITLE
v16.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>io.voucherify.client</groupId>
   <artifactId>voucherify-java-sdk</artifactId>
-  <version>16.0.0</version>
+  <version>16.0.1</version>
   <scope>compile</scope>
 </dependency>
 ```
@@ -69,7 +69,7 @@ Add this dependency to your project's build file:
   }
 
   dependencies {
-     implementation "io.voucherify.client:voucherify-java-sdk:16.0.0"
+     implementation "io.voucherify.client:voucherify-java-sdk:16.0.1"
   }
 ```
 
@@ -83,7 +83,7 @@ mvn clean package
 
 Then manually install the following JARs:
 
-* `target/voucherify-java-sdk-16.0.0.jar`
+* `target/voucherify-java-sdk-16.0.1.jar`
 * `target/lib/*.jar`
 
 ## 🚀 Running code
@@ -143,6 +143,8 @@ Read more about how to Contribute to Voucherify Java SDK by visiting main repo [
 Remember that this SDK is auto generated (except of the tests) so changes made here will be overwritten by generator.
 
 ## 📅 Changelog
+- **2024-11-04** - `16.0.1`
+  - Added support for returning `campaign_id` and `campaign_name` in stackable validation endpoint, when `redeemable` option is expanded
 - **2024-10-28** - `16.0.0`
   - Added missing `enums` in few filters models
   - !!! BREAKING CHANGES !!!

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 group = 'io.voucherify.client'
-version = '16.0.0'
+version = '16.0.1'
 
 buildscript {
     repositories {

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file(".")).
   settings(
     organization := "io.voucherify.client",
     name := "voucherify-java-sdk",
-    version := "16.0.0",
+    version := "16.0.1",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
     javacOptions in compile ++= Seq("-Xlint:deprecation"),

--- a/docs/ClientValidationsValidateResponseBodyRedeemablesItem.md
+++ b/docs/ClientValidationsValidateResponseBodyRedeemablesItem.md
@@ -16,6 +16,8 @@
 |**result** | [**ClientValidationsValidateResponseBodyRedeemablesItemResult**](ClientValidationsValidateResponseBodyRedeemablesItemResult.md) |  |
 |**metadata** | **Object** | The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable. |
 |**categories** | [**List&lt;CategoryWithStackingRulesType&gt;**](CategoryWithStackingRulesType.md) |  |
+|**campaignName** | **String** | Campaign name |
+|**campaignId** | **String** | Unique campaign ID assigned by Voucherify. |
 
 
 

--- a/docs/ValidationsRedeemableInapplicable.md
+++ b/docs/ValidationsRedeemableInapplicable.md
@@ -13,6 +13,8 @@
 |**result** | [**ValidationsRedeemableInapplicableResult**](ValidationsRedeemableInapplicableResult.md) |  |
 |**metadata** | **Object** | The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable. |
 |**categories** | [**List&lt;CategoryWithStackingRulesType&gt;**](CategoryWithStackingRulesType.md) |  |
+|**campaignName** | **String** | Campaign name |
+|**campaignId** | **String** | Unique campaign ID assigned by Voucherify. |
 
 
 

--- a/docs/ValidationsRedeemableSkipped.md
+++ b/docs/ValidationsRedeemableSkipped.md
@@ -13,6 +13,8 @@
 |**result** | [**ValidationsRedeemableSkippedResult**](ValidationsRedeemableSkippedResult.md) |  |
 |**metadata** | **Object** | The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable. |
 |**categories** | [**List&lt;CategoryWithStackingRulesType&gt;**](CategoryWithStackingRulesType.md) |  |
+|**campaignName** | **String** | Campaign name |
+|**campaignId** | **String** | Unique campaign ID assigned by Voucherify. |
 
 
 

--- a/docs/ValidationsValidateResponseBodyRedeemablesItem.md
+++ b/docs/ValidationsValidateResponseBodyRedeemablesItem.md
@@ -16,6 +16,8 @@
 |**result** | [**ValidationsValidateResponseBodyRedeemablesItemResult**](ValidationsValidateResponseBodyRedeemablesItemResult.md) |  |
 |**metadata** | **Object** | The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable. |
 |**categories** | [**List&lt;CategoryWithStackingRulesType&gt;**](CategoryWithStackingRulesType.md) |  |
+|**campaignName** | **String** | Campaign name |
+|**campaignId** | **String** | Unique campaign ID assigned by Voucherify. |
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>voucherify-java-sdk</artifactId>
     <packaging>jar</packaging>
     <name>voucherify-java-sdk</name>
-    <version>16.0.0</version>
+    <version>16.0.1</version>
     <url>https://github.com/openapitools/openapi-generator</url>
     <description>OpenAPI Java</description>
     <scm>

--- a/src/main/java/io/voucherify/client/ApiClient.java
+++ b/src/main/java/io/voucherify/client/ApiClient.java
@@ -172,7 +172,7 @@ public class ApiClient {
         json = new JSON();
 
         // Set default User-Agent.
-        setUserAgent("OpenAPI-Java-SDK/16.0.0");
+        setUserAgent("OpenAPI-Java-SDK/16.0.1");
         addDefaultHeader("X-Voucherify-Channel", "Java-SDK");
 
         authentications = new HashMap<String, Authentication>();

--- a/src/main/java/io/voucherify/client/Configuration.java
+++ b/src/main/java/io/voucherify/client/Configuration.java
@@ -16,7 +16,7 @@ package io.voucherify.client;
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 
 public class Configuration {
-    public static final String VERSION = "16.0.0";
+    public static final String VERSION = "16.0.1";
 
     private static ApiClient defaultApiClient = new ApiClient();
 

--- a/src/main/java/io/voucherify/client/model/ClientValidationsValidateResponseBodyRedeemablesItem.java
+++ b/src/main/java/io/voucherify/client/model/ClientValidationsValidateResponseBodyRedeemablesItem.java
@@ -192,6 +192,14 @@ public class ClientValidationsValidateResponseBodyRedeemablesItem {
   @SerializedName(SERIALIZED_NAME_CATEGORIES)
   private List<CategoryWithStackingRulesType> categories;
 
+  public static final String SERIALIZED_NAME_CAMPAIGN_NAME = "campaign_name";
+  @SerializedName(SERIALIZED_NAME_CAMPAIGN_NAME)
+  private String campaignName;
+
+  public static final String SERIALIZED_NAME_CAMPAIGN_ID = "campaign_id";
+  @SerializedName(SERIALIZED_NAME_CAMPAIGN_ID)
+  private String campaignId;
+
   public ClientValidationsValidateResponseBodyRedeemablesItem() {
   }
 
@@ -392,6 +400,48 @@ public class ClientValidationsValidateResponseBodyRedeemablesItem {
   }
 
 
+  public ClientValidationsValidateResponseBodyRedeemablesItem campaignName(String campaignName) {
+    
+    this.campaignName = campaignName;
+    return this;
+  }
+
+   /**
+   * Campaign name
+   * @return campaignName
+  **/
+  @javax.annotation.Nullable
+  public String getCampaignName() {
+    return campaignName;
+  }
+
+
+  public void setCampaignName(String campaignName) {
+    this.campaignName = campaignName;
+  }
+
+
+  public ClientValidationsValidateResponseBodyRedeemablesItem campaignId(String campaignId) {
+    
+    this.campaignId = campaignId;
+    return this;
+  }
+
+   /**
+   * Unique campaign ID assigned by Voucherify.
+   * @return campaignId
+  **/
+  @javax.annotation.Nullable
+  public String getCampaignId() {
+    return campaignId;
+  }
+
+
+  public void setCampaignId(String campaignId) {
+    this.campaignId = campaignId;
+  }
+
+
 
   @Override
   public boolean equals(Object o) {
@@ -410,7 +460,9 @@ public class ClientValidationsValidateResponseBodyRedeemablesItem {
         Objects.equals(this.inapplicableTo, clientValidationsValidateResponseBodyRedeemablesItem.inapplicableTo) &&
         Objects.equals(this.result, clientValidationsValidateResponseBodyRedeemablesItem.result) &&
         Objects.equals(this.metadata, clientValidationsValidateResponseBodyRedeemablesItem.metadata) &&
-        Objects.equals(this.categories, clientValidationsValidateResponseBodyRedeemablesItem.categories);
+        Objects.equals(this.categories, clientValidationsValidateResponseBodyRedeemablesItem.categories) &&
+        Objects.equals(this.campaignName, clientValidationsValidateResponseBodyRedeemablesItem.campaignName) &&
+        Objects.equals(this.campaignId, clientValidationsValidateResponseBodyRedeemablesItem.campaignId);
   }
 
   private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
@@ -419,7 +471,7 @@ public class ClientValidationsValidateResponseBodyRedeemablesItem {
 
   @Override
   public int hashCode() {
-    return Objects.hash(status, id, _object, order, applicableTo, inapplicableTo, result, metadata, categories);
+    return Objects.hash(status, id, _object, order, applicableTo, inapplicableTo, result, metadata, categories, campaignName, campaignId);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -442,6 +494,8 @@ public class ClientValidationsValidateResponseBodyRedeemablesItem {
     sb.append("    result: ").append(toIndentedString(result)).append("\n");
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
     sb.append("    categories: ").append(toIndentedString(categories)).append("\n");
+    sb.append("    campaignName: ").append(toIndentedString(campaignName)).append("\n");
+    sb.append("    campaignId: ").append(toIndentedString(campaignId)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -473,6 +527,8 @@ public class ClientValidationsValidateResponseBodyRedeemablesItem {
     openapiFields.add("result");
     openapiFields.add("metadata");
     openapiFields.add("categories");
+    openapiFields.add("campaign_name");
+    openapiFields.add("campaign_id");
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>();

--- a/src/main/java/io/voucherify/client/model/ValidationsRedeemableInapplicable.java
+++ b/src/main/java/io/voucherify/client/model/ValidationsRedeemableInapplicable.java
@@ -173,6 +173,14 @@ public class ValidationsRedeemableInapplicable {
   @SerializedName(SERIALIZED_NAME_CATEGORIES)
   private List<CategoryWithStackingRulesType> categories;
 
+  public static final String SERIALIZED_NAME_CAMPAIGN_NAME = "campaign_name";
+  @SerializedName(SERIALIZED_NAME_CAMPAIGN_NAME)
+  private String campaignName;
+
+  public static final String SERIALIZED_NAME_CAMPAIGN_ID = "campaign_id";
+  @SerializedName(SERIALIZED_NAME_CAMPAIGN_ID)
+  private String campaignId;
+
   public ValidationsRedeemableInapplicable() {
   }
 
@@ -310,6 +318,48 @@ public class ValidationsRedeemableInapplicable {
   }
 
 
+  public ValidationsRedeemableInapplicable campaignName(String campaignName) {
+    
+    this.campaignName = campaignName;
+    return this;
+  }
+
+   /**
+   * Campaign name
+   * @return campaignName
+  **/
+  @javax.annotation.Nullable
+  public String getCampaignName() {
+    return campaignName;
+  }
+
+
+  public void setCampaignName(String campaignName) {
+    this.campaignName = campaignName;
+  }
+
+
+  public ValidationsRedeemableInapplicable campaignId(String campaignId) {
+    
+    this.campaignId = campaignId;
+    return this;
+  }
+
+   /**
+   * Unique campaign ID assigned by Voucherify.
+   * @return campaignId
+  **/
+  @javax.annotation.Nullable
+  public String getCampaignId() {
+    return campaignId;
+  }
+
+
+  public void setCampaignId(String campaignId) {
+    this.campaignId = campaignId;
+  }
+
+
 
   @Override
   public boolean equals(Object o) {
@@ -325,7 +375,9 @@ public class ValidationsRedeemableInapplicable {
         Objects.equals(this._object, validationsRedeemableInapplicable._object) &&
         Objects.equals(this.result, validationsRedeemableInapplicable.result) &&
         Objects.equals(this.metadata, validationsRedeemableInapplicable.metadata) &&
-        Objects.equals(this.categories, validationsRedeemableInapplicable.categories);
+        Objects.equals(this.categories, validationsRedeemableInapplicable.categories) &&
+        Objects.equals(this.campaignName, validationsRedeemableInapplicable.campaignName) &&
+        Objects.equals(this.campaignId, validationsRedeemableInapplicable.campaignId);
   }
 
   private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
@@ -334,7 +386,7 @@ public class ValidationsRedeemableInapplicable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(status, id, _object, result, metadata, categories);
+    return Objects.hash(status, id, _object, result, metadata, categories, campaignName, campaignId);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -354,6 +406,8 @@ public class ValidationsRedeemableInapplicable {
     sb.append("    result: ").append(toIndentedString(result)).append("\n");
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
     sb.append("    categories: ").append(toIndentedString(categories)).append("\n");
+    sb.append("    campaignName: ").append(toIndentedString(campaignName)).append("\n");
+    sb.append("    campaignId: ").append(toIndentedString(campaignId)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -382,6 +436,8 @@ public class ValidationsRedeemableInapplicable {
     openapiFields.add("result");
     openapiFields.add("metadata");
     openapiFields.add("categories");
+    openapiFields.add("campaign_name");
+    openapiFields.add("campaign_id");
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>();

--- a/src/main/java/io/voucherify/client/model/ValidationsRedeemableSkipped.java
+++ b/src/main/java/io/voucherify/client/model/ValidationsRedeemableSkipped.java
@@ -173,6 +173,14 @@ public class ValidationsRedeemableSkipped {
   @SerializedName(SERIALIZED_NAME_CATEGORIES)
   private List<CategoryWithStackingRulesType> categories;
 
+  public static final String SERIALIZED_NAME_CAMPAIGN_NAME = "campaign_name";
+  @SerializedName(SERIALIZED_NAME_CAMPAIGN_NAME)
+  private String campaignName;
+
+  public static final String SERIALIZED_NAME_CAMPAIGN_ID = "campaign_id";
+  @SerializedName(SERIALIZED_NAME_CAMPAIGN_ID)
+  private String campaignId;
+
   public ValidationsRedeemableSkipped() {
   }
 
@@ -310,6 +318,48 @@ public class ValidationsRedeemableSkipped {
   }
 
 
+  public ValidationsRedeemableSkipped campaignName(String campaignName) {
+    
+    this.campaignName = campaignName;
+    return this;
+  }
+
+   /**
+   * Campaign name
+   * @return campaignName
+  **/
+  @javax.annotation.Nullable
+  public String getCampaignName() {
+    return campaignName;
+  }
+
+
+  public void setCampaignName(String campaignName) {
+    this.campaignName = campaignName;
+  }
+
+
+  public ValidationsRedeemableSkipped campaignId(String campaignId) {
+    
+    this.campaignId = campaignId;
+    return this;
+  }
+
+   /**
+   * Unique campaign ID assigned by Voucherify.
+   * @return campaignId
+  **/
+  @javax.annotation.Nullable
+  public String getCampaignId() {
+    return campaignId;
+  }
+
+
+  public void setCampaignId(String campaignId) {
+    this.campaignId = campaignId;
+  }
+
+
 
   @Override
   public boolean equals(Object o) {
@@ -325,7 +375,9 @@ public class ValidationsRedeemableSkipped {
         Objects.equals(this._object, validationsRedeemableSkipped._object) &&
         Objects.equals(this.result, validationsRedeemableSkipped.result) &&
         Objects.equals(this.metadata, validationsRedeemableSkipped.metadata) &&
-        Objects.equals(this.categories, validationsRedeemableSkipped.categories);
+        Objects.equals(this.categories, validationsRedeemableSkipped.categories) &&
+        Objects.equals(this.campaignName, validationsRedeemableSkipped.campaignName) &&
+        Objects.equals(this.campaignId, validationsRedeemableSkipped.campaignId);
   }
 
   private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
@@ -334,7 +386,7 @@ public class ValidationsRedeemableSkipped {
 
   @Override
   public int hashCode() {
-    return Objects.hash(status, id, _object, result, metadata, categories);
+    return Objects.hash(status, id, _object, result, metadata, categories, campaignName, campaignId);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -354,6 +406,8 @@ public class ValidationsRedeemableSkipped {
     sb.append("    result: ").append(toIndentedString(result)).append("\n");
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
     sb.append("    categories: ").append(toIndentedString(categories)).append("\n");
+    sb.append("    campaignName: ").append(toIndentedString(campaignName)).append("\n");
+    sb.append("    campaignId: ").append(toIndentedString(campaignId)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -382,6 +436,8 @@ public class ValidationsRedeemableSkipped {
     openapiFields.add("result");
     openapiFields.add("metadata");
     openapiFields.add("categories");
+    openapiFields.add("campaign_name");
+    openapiFields.add("campaign_id");
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>();

--- a/src/main/java/io/voucherify/client/model/ValidationsValidateResponseBodyRedeemablesItem.java
+++ b/src/main/java/io/voucherify/client/model/ValidationsValidateResponseBodyRedeemablesItem.java
@@ -192,6 +192,14 @@ public class ValidationsValidateResponseBodyRedeemablesItem {
   @SerializedName(SERIALIZED_NAME_CATEGORIES)
   private List<CategoryWithStackingRulesType> categories;
 
+  public static final String SERIALIZED_NAME_CAMPAIGN_NAME = "campaign_name";
+  @SerializedName(SERIALIZED_NAME_CAMPAIGN_NAME)
+  private String campaignName;
+
+  public static final String SERIALIZED_NAME_CAMPAIGN_ID = "campaign_id";
+  @SerializedName(SERIALIZED_NAME_CAMPAIGN_ID)
+  private String campaignId;
+
   public ValidationsValidateResponseBodyRedeemablesItem() {
   }
 
@@ -392,6 +400,48 @@ public class ValidationsValidateResponseBodyRedeemablesItem {
   }
 
 
+  public ValidationsValidateResponseBodyRedeemablesItem campaignName(String campaignName) {
+    
+    this.campaignName = campaignName;
+    return this;
+  }
+
+   /**
+   * Campaign name
+   * @return campaignName
+  **/
+  @javax.annotation.Nullable
+  public String getCampaignName() {
+    return campaignName;
+  }
+
+
+  public void setCampaignName(String campaignName) {
+    this.campaignName = campaignName;
+  }
+
+
+  public ValidationsValidateResponseBodyRedeemablesItem campaignId(String campaignId) {
+    
+    this.campaignId = campaignId;
+    return this;
+  }
+
+   /**
+   * Unique campaign ID assigned by Voucherify.
+   * @return campaignId
+  **/
+  @javax.annotation.Nullable
+  public String getCampaignId() {
+    return campaignId;
+  }
+
+
+  public void setCampaignId(String campaignId) {
+    this.campaignId = campaignId;
+  }
+
+
 
   @Override
   public boolean equals(Object o) {
@@ -410,7 +460,9 @@ public class ValidationsValidateResponseBodyRedeemablesItem {
         Objects.equals(this.inapplicableTo, validationsValidateResponseBodyRedeemablesItem.inapplicableTo) &&
         Objects.equals(this.result, validationsValidateResponseBodyRedeemablesItem.result) &&
         Objects.equals(this.metadata, validationsValidateResponseBodyRedeemablesItem.metadata) &&
-        Objects.equals(this.categories, validationsValidateResponseBodyRedeemablesItem.categories);
+        Objects.equals(this.categories, validationsValidateResponseBodyRedeemablesItem.categories) &&
+        Objects.equals(this.campaignName, validationsValidateResponseBodyRedeemablesItem.campaignName) &&
+        Objects.equals(this.campaignId, validationsValidateResponseBodyRedeemablesItem.campaignId);
   }
 
   private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
@@ -419,7 +471,7 @@ public class ValidationsValidateResponseBodyRedeemablesItem {
 
   @Override
   public int hashCode() {
-    return Objects.hash(status, id, _object, order, applicableTo, inapplicableTo, result, metadata, categories);
+    return Objects.hash(status, id, _object, order, applicableTo, inapplicableTo, result, metadata, categories, campaignName, campaignId);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -442,6 +494,8 @@ public class ValidationsValidateResponseBodyRedeemablesItem {
     sb.append("    result: ").append(toIndentedString(result)).append("\n");
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
     sb.append("    categories: ").append(toIndentedString(categories)).append("\n");
+    sb.append("    campaignName: ").append(toIndentedString(campaignName)).append("\n");
+    sb.append("    campaignId: ").append(toIndentedString(campaignId)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -473,6 +527,8 @@ public class ValidationsValidateResponseBodyRedeemablesItem {
     openapiFields.add("result");
     openapiFields.add("metadata");
     openapiFields.add("categories");
+    openapiFields.add("campaign_name");
+    openapiFields.add("campaign_id");
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>();


### PR DESCRIPTION
- **2024-11-04** - `16.0.1`
  - Added support for returning `campaign_id` and `campaign_name` in stackable validation endpoint, when `redeemable` option is expanded